### PR TITLE
Add in a phidgets team.

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -55,6 +55,7 @@ locals {
       local.ouxt_team,
       local.pal_robotics_team,
       local.perception_team,
+      local.phidgets_team,
       local.picknik_team,
       local.plotjuggler_team,
       local.rclc_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -54,6 +54,7 @@ locals {
     local.ouxt_repositories,
     local.pal_robotics_repositories,
     local.perception_repositories,
+    local.phidgets_repositories,
     local.picknik_repositories,
     local.plotjuggler_repositories,
     local.rclc_repositories,

--- a/phidgets.tf
+++ b/phidgets.tf
@@ -1,0 +1,16 @@
+locals {
+  phidgets_team = [
+    "clalancette",
+    "mintar",
+  ]
+  phidgets_repositories = [
+    "phidgets_drivers-release",
+  ]
+}
+
+module "phidgets_team" {
+  source = "./modules/release_team"
+  team_name = "phidgets"
+  members = local.phidgets_team
+  repositories = local.phidgets_repositories
+}


### PR DESCRIPTION
This is to restore mintar's access to
https://github.com/ros2-gbp/phidgets_drivers-release.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>