### PR TITLE
Add zbar_ros_team

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -97,6 +97,7 @@ locals {
       local.vision_msgs_team,
       local.visp_team,
       local.xacro_team,
+      local.zbar_ros_team,
       local.zenoh_bridge_dds_team,
     ),
     local.ros_admins

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -96,6 +96,7 @@ locals {
     local.vision_msgs_repositories,
     local.visp_repositories,
     local.xacro_repositories,
+    local.zbar_ros_repositories,
     local.zenoh_bridge_dds_repositories,
   )
 }

--- a/zbar_ros.tf
+++ b/zbar_ros.tf
@@ -1,0 +1,18 @@
+locals {
+  zbar_ros_team = [
+    "ijnek"
+    "mikepurvis"
+    "paulbovbel"
+  ]
+
+  zbar_ros_repositories = [
+    "zbar_ros-release"
+  ]
+}
+
+module "zbar_ros_team" {
+  source = "./modules/release_team"
+  team_name = "zbar_ros"
+  members = local.zbar_ros_team
+  repositories = local.zbar_ros_repositories
+}


### PR DESCRIPTION
* Name of the new release team: zbar_ros
* Release repositories to add:
  * [zbar_ros](https://github.com/ros-drivers/zbar_ros)

Decided to create new release repo for ROS2, upon [discussion](https://github.com/ros-drivers/zbar_ros/issues/12#event-6104095654).

I'm (@ijnek) the only maintainer according to the package.xml of zbar_ros, but i've added all usernames of those that were in [ros-drivers-gbp/Zbar Maintainers](https://github.com/orgs/ros-drivers-gbp/teams/zbar-maintainers/members). Is this an issue? If it is, should I add all three as maintainers in package.xml, or should I remove the other @mikepurvis and @paulbovbel from `zbar_ros.tf`?