### PR TITLE
Always count this repository as managed.

### DIFF
--- a/00-output.tf
+++ b/00-output.tf
@@ -13,6 +13,6 @@ output "unmanaged_members" {
 output "unmanaged_repositories" {
   value = setsubtract(
     [for repo in data.github_organization.ros2-gbp.repositories : trimprefix(repo, "ros2-gbp/")],
-    local.organization_repositories,
+    setunion(local.organization_repositories, ["ros2-gbp-github-org"])
   )
 }


### PR DESCRIPTION
Otherwise it appears in the unmanaged repositories output since it is declared separately from the bulk repositories.