### PR TITLE
Add acceleration release team

### DIFF
--- a/acceleration_wg.tf
+++ b/acceleration_wg.tf
@@ -1,0 +1,15 @@
+locals {
+  acceleration_wg_team = [
+    "vmayoral",
+    "methyldragon",
+  ]
+  acceleration_wg_repositories = [
+  ]
+}
+
+module "acceleration_wg_team" {
+  source       = "./modules/release_team"
+  team_name    = "acceleration_wg"
+  members      = local.acceleration_wg_team
+  repositories = local.acceleration_wg_repositories
+}


### PR DESCRIPTION
## Description
Release team to prep for release of some [Hardware Acceleration Working Group](https://github.com/ros-acceleration) packages.
I will be adding myself temporarily (@methyldragon) to help with the process.

Currently the packages have upstream repositories only, so I would like to also request that **new release repositories are made on this org**.

After the release team is made, I will be separately making release requests.

## Details
Name of the new release team: acceleration_wg

### Release repositories to create (upstream repositories hyperlinked)
5 repositories in total.

**ament Extensions**
- ament_acceleration-release ([upstream](https://github.com/ros-acceleration/ament_acceleration))
- ament_vitis-release ([upstream](https://github.com/ros-acceleration/ament_vitis))

**Packages**
- vitis_common-release ([upstream](https://github.com/ros-acceleration/vitis_common))
- tracetools_acceleration-release ([upstream](https://github.com/ros-acceleration/tracetools_acceleration))

**ros2cli Extensions**
- ros2acceleration-release ([upstream](https://github.com/ros-acceleration/ros2acceleration))

### Team members
- @vmayoral
- @methyldragon

## Additional Notes
If I need to be adding the release repositories that are yet-to-be-created to the `.tf` group, let me know, and I'll do that!