### PR TITLE
Add release repositories for mrpt team.

### DIFF
--- a/mrpt2.tf
+++ b/mrpt2.tf
@@ -4,11 +4,11 @@ locals {
     "jolting",
   ]
   mrpt2_repositories = [
-    "mprt_navigation-release",
-    "mprt_sensors-release",
-    "mprt_slam-release",
     "mrpt2-release",
     "mrpt_msgs-release",
+    "mrpt_navigation-release",
+    "mrpt_sensors-release",
+    "mrpt_slam-release",
     "pose_cov_ops-release",
   ]
 }

--- a/mrpt2.tf
+++ b/mrpt2.tf
@@ -4,7 +4,12 @@ locals {
     "jolting",
   ]
   mrpt2_repositories = [
+    "mprt_navigation-release",
+    "mprt_sensors-release",
+    "mprt_slam-release",
     "mrpt2-release",
+    "mrpt_msgs-release",
+    "pose_cov_ops-release",
   ]
 }
 


### PR DESCRIPTION
mrpt_msgs-release has been imported from https://github.com/mrpt-ros2-pkg-release/mrpt_msgs-release and the rest
are new.

Closes https://github.com/ros2-gbp/ros2-gbp-github-org/issues/25