### PR TITLE
Declare dependency on membership and repositories for each release team module.

### DIFF
--- a/acceleration_wg.tf
+++ b/acceleration_wg.tf
@@ -18,4 +18,5 @@ module "acceleration_wg_team" {
   team_name    = "acceleration_wg"
   members      = local.acceleration_wg_team
   repositories = local.acceleration_wg_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/ackermann_msgs.tf
+++ b/ackermann_msgs.tf
@@ -12,4 +12,5 @@ module "ackermann_msgs_team" {
   team_name    = "ackermann_msgs"
   members      = local.ackermann_msgs_team
   repositories = local.ackermann_msgs_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/apex.tf
+++ b/apex.tf
@@ -19,4 +19,5 @@ module "apex_team" {
   team_name    = "apex"
   members      = local.apex_team
   repositories = local.apex_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/apriltag.tf
+++ b/apriltag.tf
@@ -13,4 +13,5 @@ module "apriltag_team" {
   team_name    = "apriltag"
   members      = local.apriltag_team
   repositories = local.apriltag_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/astuff.tf
+++ b/astuff.tf
@@ -13,4 +13,5 @@ module "astuff_team" {
   team_name    = "astuff"
   members      = local.astuff_team
   repositories = local.astuff_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/async_web_server_cpp.tf
+++ b/async_web_server_cpp.tf
@@ -13,4 +13,5 @@ module "async_web_server_cpp_team" {
   team_name    = "async_web_server_cpp"
   members      = local.async_web_server_cpp_team
   repositories = local.async_web_server_cpp_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/autoware.tf
+++ b/autoware.tf
@@ -20,4 +20,5 @@ module "autoware_team" {
   team_name    = "autoware"
   members      = local.autoware_team
   repositories = local.autoware_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/aws.tf
+++ b/aws.tf
@@ -12,4 +12,5 @@ module "aws_team" {
   team_name    = "aws"
   members      = local.aws_team
   repositories = local.aws_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/behaviortree.tf
+++ b/behaviortree.tf
@@ -12,4 +12,5 @@ module "behaviortree_team" {
   team_name    = "behaviortree"
   members      = local.behaviortree_team
   repositories = local.behaviortree_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/bno055.tf
+++ b/bno055.tf
@@ -12,4 +12,5 @@ module "bno055_team" {
   team_name    = "bno055"
   members      = local.bno055_team
   repositories = local.bno055_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/connextdds.tf
+++ b/connextdds.tf
@@ -12,4 +12,5 @@ module "connextdds_team" {
   team_name    = "connextdds"
   members      = local.connextdds_team
   repositories = local.connextdds_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/control.tf
+++ b/control.tf
@@ -18,4 +18,5 @@ module "control_team" {
   team_name    = "control"
   members      = local.control_team
   repositories = local.control_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/control_box_rst.tf
+++ b/control_box_rst.tf
@@ -12,4 +12,5 @@ module "control_box_rst_team" {
   team_name    = "control_box_rst"
   members      = local.control_box_rst_team
   repositories = local.control_box_rst_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/cyberbotics.tf
+++ b/cyberbotics.tf
@@ -16,4 +16,5 @@ module "cyberbotics_team" {
   team_name    = "cyberbotics"
   members      = local.cyberbotics_team
   repositories = local.cyberbotics_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/cyclonedds.tf
+++ b/cyclonedds.tf
@@ -14,4 +14,5 @@ module "cyclonedds_team" {
   team_name    = "cyclonedds"
   members      = local.cyclonedds_team
   repositories = local.cyclonedds_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/diagnostics.tf
+++ b/diagnostics.tf
@@ -13,4 +13,5 @@ module "diagnostics_team" {
   team_name    = "diagnostics"
   members      = local.diagnostics_team
   repositories = local.diagnostics_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/dolly.tf
+++ b/dolly.tf
@@ -12,4 +12,5 @@ module "dolly_team" {
   team_name    = "dolly"
   members      = local.dolly_team
   repositories = local.dolly_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/fastcdr.tf
+++ b/fastcdr.tf
@@ -16,4 +16,5 @@ module "fastcdr_team" {
   team_name    = "fastcdr"
   members      = local.fastcdr_team
   repositories = local.fastcdr_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/fmi.tf
+++ b/fmi.tf
@@ -13,4 +13,5 @@ module "fmi_team" {
   team_name    = "fmi"
   members      = local.fmi_team
   repositories = local.fmi_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/fogros2.tf
+++ b/fogros2.tf
@@ -20,4 +20,5 @@ module "fogros2_team" {
   team_name    = "fogros2"
   members      = local.fogros2_team
   repositories = local.fogros2_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/four_wheel_steering_msgs.tf
+++ b/four_wheel_steering_msgs.tf
@@ -12,4 +12,5 @@ module "four_wheel_steering_msgs_team" {
   team_name    = "four_wheel_steering_msgs"
   members      = local.four_wheel_steering_msgs_team
   repositories = local.four_wheel_steering_msgs_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/foxglove_msgs.tf
+++ b/foxglove_msgs.tf
@@ -13,4 +13,5 @@ module "foxglove_msgs_team" {
   team_name    = "foxglove_msgs"
   members      = local.foxglove_msgs_team
   repositories = local.foxglove_msgs_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/gazebo.tf
+++ b/gazebo.tf
@@ -23,4 +23,5 @@ module "gazebo_team" {
   team_name    = "gazebo"
   members      = local.gazebo_team
   repositories = local.gazebo_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/geographic_info.tf
+++ b/geographic_info.tf
@@ -12,4 +12,5 @@ module "geographic_info_team" {
   team_name    = "geographic_info"
   members      = local.geographic_info_team
   repositories = local.geographic_info_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/grbl.tf
+++ b/grbl.tf
@@ -13,4 +13,5 @@ module "grbl_team" {
   team_name    = "grbl"
   members      = local.grbl_team
   repositories = local.grbl_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/gscam.tf
+++ b/gscam.tf
@@ -13,4 +13,5 @@ module "gscam_team" {
   team_name    = "gscam"
   members      = local.gscam_team
   repositories = local.gscam_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/gurumdds.tf
+++ b/gurumdds.tf
@@ -14,4 +14,5 @@ module "gurumdds_team" {
   team_name    = "gurumdds"
   members      = local.gurumdds_team
   repositories = local.gurumdds_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/iceoryx.tf
+++ b/iceoryx.tf
@@ -14,4 +14,5 @@ module "iceoryx_team" {
   team_name    = "iceoryx"
   members      = local.iceoryx_team
   repositories = local.iceoryx_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/ifm3d.tf
+++ b/ifm3d.tf
@@ -12,4 +12,5 @@ module "ifm3d_team" {
   team_name    = "ifm3d"
   members      = local.ifm3d_team
   repositories = local.ifm3d_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/ijnek.tf
+++ b/ijnek.tf
@@ -16,4 +16,5 @@ module "ijnek_team" {
   team_name    = "ijnek"
   members      = local.ijnek_team
   repositories = local.ijnek_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/imu_tools.tf
+++ b/imu_tools.tf
@@ -12,4 +12,5 @@ module "imu_tools_team" {
   team_name    = "imu_tools"
   members      = local.imu_tools_team
   repositories = local.imu_tools_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/irobot_education.tf
+++ b/irobot_education.tf
@@ -15,4 +15,5 @@ module "irobot_education_team" {
   team_name    = "irobot_education"
   members      = local.irobot_education_team
   repositories = local.irobot_education_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/lanelet2.tf
+++ b/lanelet2.tf
@@ -12,4 +12,5 @@ module "lanelet2_team" {
   team_name    = "lanelet2"
   members      = local.lanelet2_team
   repositories = local.lanelet2_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/lgsvl.tf
+++ b/lgsvl.tf
@@ -12,4 +12,5 @@ module "lgsvl_team" {
   team_name    = "lgsvl"
   members      = local.lgsvl_team
   repositories = local.lgsvl_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/libg2o.tf
+++ b/libg2o.tf
@@ -12,4 +12,5 @@ module "libg2o_team" {
   team_name    = "libg2o"
   members      = local.libg2o_team
   repositories = local.libg2o_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/locator_ros_bridge.tf
+++ b/locator_ros_bridge.tf
@@ -13,4 +13,5 @@ module "locator_ros_bridge_team" {
   team_name    = "locator_ros_bridge"
   members      = local.locator_ros_bridge_team
   repositories = local.locator_ros_bridge_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/mavlink.tf
+++ b/mavlink.tf
@@ -13,4 +13,5 @@ module "mavlink_team" {
   team_name    = "mavlink"
   members      = local.mavlink_team
   repositories = local.mavlink_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/micro_ros_diagnostics.tf
+++ b/micro_ros_diagnostics.tf
@@ -14,4 +14,5 @@ module "micro_ros_diagnostics_team" {
   team_name    = "micro_ros_diagnostics"
   members      = local.micro_ros_diagnostics_team
   repositories = local.micro_ros_diagnostics_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/micro_ros_msgs.tf
+++ b/micro_ros_msgs.tf
@@ -12,4 +12,5 @@ module "micro_ros_msgs_team" {
   team_name    = "micro_ros_msgs"
   members      = local.micro_ros_msgs_team
   repositories = local.micro_ros_msgs_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/microstrain.tf
+++ b/microstrain.tf
@@ -13,4 +13,5 @@ module "microstrain_team" {
   team_name    = "microstrain"
   members      = local.microstrain_team
   repositories = local.microstrain_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/moveit.tf
+++ b/moveit.tf
@@ -26,4 +26,5 @@ module "moveit_team" {
   team_name    = "moveit"
   members      = local.moveit_team
   repositories = local.moveit_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/mrpt2.tf
+++ b/mrpt2.tf
@@ -18,4 +18,5 @@ module "mrpt2_team" {
   team_name    = "mrpt2"
   members      = local.mrpt2_team
   repositories = local.mrpt2_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/mrt_cmake_modules.tf
+++ b/mrt_cmake_modules.tf
@@ -12,4 +12,5 @@ module "mrt_cmake_modules_team" {
   team_name    = "mrt_cmake_modules"
   members      = local.mrt_cmake_modules_team
   repositories = local.mrt_cmake_modules_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/navigation.tf
+++ b/navigation.tf
@@ -18,4 +18,5 @@ module "navigation_team" {
   team_name    = "navigation"
   members      = local.navigation_team
   repositories = local.navigation_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/neobotix.tf
+++ b/neobotix.tf
@@ -12,4 +12,5 @@ module "neobotix_team" {
   team_name    = "neobotix"
   members      = local.neobotix_team
   repositories = local.neobotix_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/nmea.tf
+++ b/nmea.tf
@@ -13,4 +13,5 @@ module "nmea_team" {
   team_name    = "nmea"
   members      = local.nmea_team
   repositories = local.nmea_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/nobleo.tf
+++ b/nobleo.tf
@@ -13,4 +13,5 @@ module "nobleo_team" {
   team_name    = "nobleo"
   members      = local.nobleo_team
   repositories = local.nobleo_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/nodl.tf
+++ b/nodl.tf
@@ -14,4 +14,5 @@ module "nodl_team" {
   team_name    = "nodl"
   members      = local.nodl_team
   repositories = local.nodl_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/ntpd_driver.tf
+++ b/ntpd_driver.tf
@@ -12,4 +12,5 @@ module "ntpd_driver_team" {
   team_name    = "ntpd_driver"
   members      = local.ntpd_driver_team
   repositories = local.ntpd_driver_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/object_analytics.tf
+++ b/object_analytics.tf
@@ -12,4 +12,5 @@ module "object_analytics_team" {
   team_name    = "object_analytics"
   members      = local.object_analytics_team
   repositories = local.object_analytics_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/octomap.tf
+++ b/octomap.tf
@@ -17,4 +17,5 @@ module "octomap_team" {
   team_name    = "octomap"
   members      = local.octomap_team
   repositories = local.octomap_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/ompl.tf
+++ b/ompl.tf
@@ -12,4 +12,5 @@ module "ompl_team" {
   team_name    = "ompl"
   members      = local.ompl_team
   repositories = local.ompl_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/ouster_drivers.tf
+++ b/ouster_drivers.tf
@@ -12,4 +12,5 @@ module "ouster_drivers_team" {
   team_name    = "ouster_drivers"
   members      = local.ouster_drivers_team
   repositories = local.ouster_drivers_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/ouxt.tf
+++ b/ouxt.tf
@@ -16,4 +16,5 @@ module "ouxt_team" {
   team_name    = "ouxt"
   members      = local.ouxt_team
   repositories = local.ouxt_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/pal_robotics.tf
+++ b/pal_robotics.tf
@@ -15,4 +15,5 @@ module "pal_robotics_team" {
   team_name    = "pal_robotics"
   members      = local.pal_robotics_team
   repositories = local.pal_robotics_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/perception.tf
+++ b/perception.tf
@@ -21,4 +21,5 @@ module "perception_team" {
   team_name    = "perception"
   members      = local.perception_team
   repositories = local.perception_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/phidgets.tf
+++ b/phidgets.tf
@@ -13,4 +13,5 @@ module "phidgets_team" {
   team_name    = "phidgets"
   members      = local.phidgets_team
   repositories = local.phidgets_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/picknik.tf
+++ b/picknik.tf
@@ -19,4 +19,5 @@ module "picknik_team" {
   team_name    = "picknik"
   members      = local.picknik_team
   repositories = local.picknik_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/plotjuggler.tf
+++ b/plotjuggler.tf
@@ -14,4 +14,5 @@ module "plotjuggler_team" {
   team_name    = "plotjuggler"
   members      = local.plotjuggler_team
   repositories = local.plotjuggler_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/rclc.tf
+++ b/rclc.tf
@@ -13,4 +13,5 @@ module "rclc_team" {
   team_name    = "rclc"
   members      = local.rclc_team
   repositories = local.rclc_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/rcpputils.tf
+++ b/rcpputils.tf
@@ -13,5 +13,6 @@ module "rcpputils_team" {
   team_name    = "rcpputils"
   members      = local.rcpputils_team
   repositories = local.rcpputils_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }
 

--- a/realsense.tf
+++ b/realsense.tf
@@ -13,4 +13,5 @@ module "realsense_team" {
   team_name    = "realsense"
   members      = local.realsense_team
   repositories = local.realsense_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/rmf.tf
+++ b/rmf.tf
@@ -31,4 +31,5 @@ module "rmf_team" {
   team_name    = "rmf"
   members      = local.rmf_team
   repositories = local.rmf_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/roboception.tf
+++ b/roboception.tf
@@ -17,4 +17,5 @@ module "roboception_team" {
   team_name    = "roboception"
   members      = local.roboception_team
   repositories = local.roboception_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/robot_localization.tf
+++ b/robot_localization.tf
@@ -13,4 +13,5 @@ module "robot_localization_team" {
   team_name    = "robot_localization"
   members      = local.robot_localization_team
   repositories = local.robot_localization_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/robotis.tf
+++ b/robotis.tf
@@ -15,4 +15,5 @@ module "robotis_team" {
   team_name    = "robotis"
   members      = local.robotis_team
   repositories = local.robotis_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/robotwebtools.tf
+++ b/robotwebtools.tf
@@ -18,4 +18,5 @@ module "robotwebtools_team" {
   team_name    = "robotwebtools"
   members      = local.robotwebtools_team
   repositories = local.robotwebtools_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/ros_canopen.tf
+++ b/ros_canopen.tf
@@ -12,4 +12,5 @@ module "ros_canopen_team" {
   team_name    = "ros_canopen"
   members      = local.ros_canopen_team
   repositories = local.ros_canopen_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/rosauth.tf
+++ b/rosauth.tf
@@ -12,4 +12,5 @@ module "rosauth_team" {
   team_name    = "rosauth"
   members      = local.rosauth_team
   repositories = local.rosauth_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/rosbag2.tf
+++ b/rosbag2.tf
@@ -16,4 +16,5 @@ module "rosbag2_team" {
   team_name    = "rosbag2"
   members      = local.rosbag2_team
   repositories = local.rosbag2_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/rospy_message_converter.tf
+++ b/rospy_message_converter.tf
@@ -12,4 +12,5 @@ module "rospy_message_converter_team" {
   team_name    = "rospy_message_converter"
   members      = local.rospy_message_converter_team
   repositories = local.rospy_message_converter_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/rplidar_ros.tf
+++ b/rplidar_ros.tf
@@ -12,4 +12,5 @@ module "rplidar_ros_team" {
   team_name    = "rplidar_ros"
   members      = local.rplidar_ros_team
   repositories = local.rplidar_ros_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/rqt.tf
+++ b/rqt.tf
@@ -31,4 +31,5 @@ module "rqt_team" {
   team_name    = "rqt"
   members      = local.rqt_team
   repositories = local.rqt_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/rtabmap.tf
+++ b/rtabmap.tf
@@ -12,4 +12,5 @@ module "rtabmap_team" {
   team_name    = "rtabmap"
   members      = local.rtabmap_team
   repositories = local.rtabmap_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/ruckig.tf
+++ b/ruckig.tf
@@ -12,4 +12,5 @@ module "ruckig_team" {
   team_name    = "ruckig"
   members      = local.ruckig_team
   repositories = local.ruckig_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/security_wg.tf
+++ b/security_wg.tf
@@ -13,4 +13,5 @@ module "security_wg_team" {
   team_name    = "security_wg"
   members      = local.security_wg_team
   repositories = local.security_wg_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/simple_launch.tf
+++ b/simple_launch.tf
@@ -12,4 +12,5 @@ module "simple_launch_team" {
   team_name    = "simple_launch"
   members      = local.simple_launch_team
   repositories = local.simple_launch_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/slider_publisher.tf
+++ b/slider_publisher.tf
@@ -12,4 +12,5 @@ module "slider_publisher_team" {
   team_name    = "slider_publisher"
   members      = local.slider_publisher_team
   repositories = local.slider_publisher_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/smacc2.tf
+++ b/smacc2.tf
@@ -12,4 +12,5 @@ module "smacc2_team" {
   team_name    = "smacc2"
   members      = local.smacc2_team
   repositories = local.smacc2_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/sports.tf
+++ b/sports.tf
@@ -17,4 +17,5 @@ module "sports_team" {
   team_name    = "sports"
   members      = local.sports_team
   repositories = local.sports_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/swri.tf
+++ b/swri.tf
@@ -17,4 +17,5 @@ module "swri_team" {
   team_name    = "swri"
   members      = local.swri_team
   repositories = local.swri_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/system_modes.tf
+++ b/system_modes.tf
@@ -13,4 +13,5 @@ module "system_modes_team" {
   team_name    = "system_modes"
   members      = local.system_modes_team
   repositories = local.system_modes_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/tf_transformations.tf
+++ b/tf_transformations.tf
@@ -12,4 +12,5 @@ module "tf_transformations_team" {
   team_name    = "tf_transformations"
   members      = local.tf_transformations_team
   repositories = local.tf_transformations_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/tier4.tf
+++ b/tier4.tf
@@ -16,5 +16,6 @@ module "tier4_team" {
   team_name    = "tier4"
   members      = local.tier4_team
   repositories = local.tier4_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }
 

--- a/tooling_wg.tf
+++ b/tooling_wg.tf
@@ -20,4 +20,5 @@ module "tooling_wg_team" {
   team_name    = "tooling_wg"
   members      = local.tooling_wg_team
   repositories = local.tooling_wg_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/tracing.tf
+++ b/tracing.tf
@@ -13,4 +13,5 @@ module "tracing_team" {
   team_name    = "tracing"
   members      = local.tracing_team
   repositories = local.tracing_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/transport_drivers.tf
+++ b/transport_drivers.tf
@@ -12,4 +12,5 @@ module "transport_drivers_team" {
   team_name    = "transport_drivers"
   members      = local.transport_drivers_team
   repositories = local.transport_drivers_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/turtlebot4.tf
+++ b/turtlebot4.tf
@@ -18,4 +18,5 @@ module "turtlebot4_team" {
   team_name    = "turtlebot4"
   members      = local.turtlebot4_team
   repositories = local.turtlebot4_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/twist_mux.tf
+++ b/twist_mux.tf
@@ -12,4 +12,5 @@ module "twist_mux_team" {
   team_name    = "twist_mux"
   members      = local.twist_mux_team
   repositories = local.twist_mux_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/ublox.tf
+++ b/ublox.tf
@@ -12,4 +12,5 @@ module "ublox_team" {
   team_name    = "ublox"
   members      = local.ublox_team
   repositories = local.ublox_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/udp_msgs.tf
+++ b/udp_msgs.tf
@@ -12,4 +12,5 @@ module "udp_msgs_team" {
   team_name    = "udp_msgs"
   members      = local.udp_msgs_team
   repositories = local.udp_msgs_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/universal_robots.tf
+++ b/universal_robots.tf
@@ -16,4 +16,5 @@ module "universal_robots_team" {
   team_name    = "universal_robots"
   members      = local.universal_robots_team
   repositories = local.universal_robots_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/urdf_tutorial.tf
+++ b/urdf_tutorial.tf
@@ -12,5 +12,6 @@ module "urdf_tutorial_team" {
   team_name    = "urdf_tutorial"
   members      = local.urdf_tutorial_team
   repositories = local.urdf_tutorial_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }
 

--- a/urg.tf
+++ b/urg.tf
@@ -14,4 +14,5 @@ module "urg_team" {
   team_name    = "urg"
   members      = local.urg_team
   repositories = local.urg_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/usb_cam.tf
+++ b/usb_cam.tf
@@ -12,4 +12,5 @@ module "usb_cam_team" {
   team_name    = "usb_cam"
   members      = local.usb_cam_team
   repositories = local.usb_cam_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/v4l2_camera.tf
+++ b/v4l2_camera.tf
@@ -11,4 +11,5 @@ module "v4l2_camera_team" {
   team_name    = "v4l2_camera"
   members      = local.v4l2_camera_team
   repositories = local.v4l2_camera_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/velodyne.tf
+++ b/velodyne.tf
@@ -14,5 +14,6 @@ module "velodyne_team" {
   team_name    = "velodyne"
   members      = local.velodyne_team
   repositories = local.velodyne_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }
 

--- a/velodyne_simulator.tf
+++ b/velodyne_simulator.tf
@@ -12,5 +12,6 @@ module "velodyne_simulator_team" {
   team_name    = "velodyne_simulator"
   members      = local.velodyne_simulator_team
   repositories = local.velodyne_simulator_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }
 

--- a/vision_msgs.tf
+++ b/vision_msgs.tf
@@ -12,4 +12,5 @@ module "vision_msgs_team" {
   team_name    = "vision_msgs"
   members      = local.vision_msgs_team
   repositories = local.vision_msgs_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/visp.tf
+++ b/visp.tf
@@ -12,4 +12,5 @@ module "visp_team" {
   team_name    = "visp"
   members      = local.visp_team
   repositories = local.visp_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/xacro.tf
+++ b/xacro.tf
@@ -13,4 +13,5 @@ module "xacro_team" {
   team_name    = "xacro"
   members      = local.xacro_team
   repositories = local.xacro_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/zbar_ros.tf
+++ b/zbar_ros.tf
@@ -15,4 +15,5 @@ module "zbar_ros_team" {
   team_name    = "zbar_ros"
   members      = local.zbar_ros_team
   repositories = local.zbar_ros_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/zenoh_bridge_dds.tf
+++ b/zenoh_bridge_dds.tf
@@ -12,4 +12,5 @@ module "zenoh_bridge_dds_team" {
   team_name    = "zenoh_bridge_dds"
   members      = local.zenoh_bridge_dds_team
   repositories = local.zenoh_bridge_dds_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }


### PR DESCRIPTION
Terraform can normally create accurate dependency models between
resources without any explicit declarations but due to the way that we
separate team membership and repositor within the release team module
and overall organization membership and repository configuration it is
possible for this project to error during terraform apply when
attempting to add a repository to a team before that repository has been
created.

This dependency is rather heavyweight since it means that none of the
modules can start until all of the members and repositories are created
but I don't know of a way to "reach out" from within the module to
declare the dependency without passing these resources as variables into
it.

depends_on *must* be a static list so we can't use any kind of
sophisticated expression to generate a list of dependencies on only the
members and repositories of this release team.
However, since new repositories and members are created somewhat
infrequently and the entire terraform apply takes a lot less time
compared to the state refresh during planning this over-declaration will
likely not impact overall performance in a significant way.


I added these to each team with the following script:
```
#!/bin/sh

for infile in $*; do
        outfile=${infile}.new
        awk '
        { print $0 }
        /^module.+{$/ { in_module = 1 }
        in_module && /repositories =/ { print "  depends_on = [github_membership.members, github_repository.repositories]" }
        ' < $infile > $outfile
        mv $outfile $infile
        terraform fmt $infile
done
```