### PR TITLE
Add new release repos for rmf

### DIFF
--- a/rmf.tf
+++ b/rmf.tf
@@ -6,6 +6,8 @@ locals {
   rmf_repositories = [
     "ament_cmake_catch2-release",
     "menge_vendor-release",
+    "nlohmann_json_schema_validator_vendor-release",
+    "pybind11_json_vendor-release",
     "rmf_api_msgs-release",
     "rmf_battery-release",
     "rmf_building_map_msgs-release",

--- a/rmf.tf
+++ b/rmf.tf
@@ -6,6 +6,7 @@ locals {
   rmf_repositories = [
     "ament_cmake_catch2-release",
     "menge_vendor-release",
+    "rmf_api_msgs-release",
     "rmf_battery-release",
     "rmf_building_map_msgs-release",
     "rmf_cmake_uncrustify-release",


### PR DESCRIPTION
Adding the following new repositories for [RMF](https://github.com/open-rmf/):

- `nlohmann_json_schema_validator_vendor-release`:  https://github.com/open-rmf/nlohmann_json_schema_validator_vendor
- `pybind11_json_vendor-release`:  https://github.com/open-rmf/pybind11_json_vendor
- `rmf_api_msgs-release`: https://github.com/open-rmf/rmf_api_msgs