### PR TITLE
Add amacneil, defunctzombie, and jtbandes to ros_foxglove_msgs-release repo

### DIFF
--- a/foxglove_msgs.tf
+++ b/foxglove_msgs.tf
@@ -1,6 +1,9 @@
 locals {
   foxglove_msgs_team = [
+    "amacneil",
+    "defunctzombie",
     "jhurliman",
+    "jtbandes",
     "wep21"
   ]
   foxglove_msgs_repositories = [


### PR DESCRIPTION
For maintenance of `foxglove_msgs`, which is moving to a new repo (see https://github.com/foxglove/message-schemas/pull/27)

cc @nuclearsandwich @clalancette 