### PR TITLE
create team and repositories for robot calibration

### DIFF
--- a/robot_calibration.tf
+++ b/robot_calibration.tf
@@ -1,0 +1,16 @@
+locals {
+  robot_calibration_team = [
+    "mikeferguson",
+  ]
+  robot_calibration_repositories = [
+    "robot_calibration-release",
+  ]
+}
+
+module "robot_calibration_team" {
+  source       = "./modules/release_team"
+  team_name    = "robot_calibration"
+  members      = local.robot_calibration_team
+  repositories = local.robot_calibration_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
I based this off the urg.tf (which I'm already part of). I want to release robot_calibration into rolling and it looks like best practice is to do that here. Figured I would skip doing an issue and just try to create a PR directly