### PR TITLE
Add soccer_vision_3d_rviz_markers repo to sports team

### DIFF
--- a/sports.tf
+++ b/sports.tf
@@ -12,6 +12,7 @@ locals {
     "rot_conv_lib-release",
     "rqt_image_overlay-release",
     "soccer_interfaces-release",
+    "soccer_vision_3d_rviz_markers-release",
   ]
 }
 


### PR DESCRIPTION
* Name of the release team: sports

* Release repositories to add:
  * [soccer_vision_3d_rviz_markers](https://github.com/ros-sports/soccer_vision_3d_rviz_markers)
    * [ ] There is no existing release repository