### PR TITLE
add maliput_infrastructure

### DIFF
--- a/maliput.tf
+++ b/maliput.tf
@@ -10,6 +10,7 @@ locals {
     "maliput_documentation-release",
     "maliput_dragway-release",
     "maliput_drake-release",
+    "maliput_infrastructure-release",
     "maliput_integration-release",
     "maliput_integration_tests-release",
     "maliput_malidrive-release",


### PR DESCRIPTION
So we can release our new metapackage https://github.com/maliput/maliput_infrastructure/pull/280