### PR TITLE
Compare usernames as lowercase. 

### DIFF
--- a/00-output.tf
+++ b/00-output.tf
@@ -1,8 +1,8 @@
 
 output "unmanaged_members" {
   value = setsubtract(
-    data.github_organization.ros2-gbp.members,
-    setunion(local.ros_admins, local.non_admin_members)
+    [for member in data.github_organization.ros2-gbp.members : lower(member)],
+    [for member in setunion(local.ros_admins, local.non_admin_members) : lower(member)]
   )
 }
 


### PR DESCRIPTION
GitHub usernames can be mixed case but are treated case insensitively by
GitHub API operations. In order to prevent false positives when various
APIs return differently cased results or a user changes their preferred
casing. convert all usernames from GitHub and the terraform
configuration files to lower case before the set subtraction.

There is a second commit which normalizes all usernames (but not repository names) in the terraform scripts to lower case in order to have a single intuitive sort order for all usernames. I see that commit as optional so if it is contentious we can just drop it.