### PR TITLE
Ignore changes to repository homepage URLs

### DIFF
--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -139,6 +139,7 @@ resource "github_repository" "repositories" {
       has_downloads,
       has_issues,
       has_wiki,
+      homepage_url,
       vulnerability_alerts
     ]
   }


### PR DESCRIPTION
There is no need to manage the homepage URL for each repository. If one is changed, leave it alone.