### PR TITLE
Add rosidl_core release repository.

### DIFF
--- a/00-ros2_core.tf
+++ b/00-ros2_core.tf
@@ -37,7 +37,7 @@ locals {
     "rclpy-release",
     "ros2cli_common_extensions-release",
     "ros_environment-release",
-    "rosidl_defaults-release",
+    "rosidl_core-release",
     "rosidl_defaults-release",
     "sros2-release",
   ]


### PR DESCRIPTION
rosidl_defaults-release was listed twice, so I removed one.