### PR TITLE
Add ros_industrial release team.

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -80,6 +80,7 @@ locals {
       local.robotis_team,
       local.robotwebtools_team,
       local.ros_canopen_team,
+      local.ros_industrial_team,
       local.ros_team,
       local.rosauth_team,
       local.rosbag2_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -79,6 +79,7 @@ locals {
     local.robotis_repositories,
     local.robotwebtools_repositories,
     local.ros_canopen_repositories,
+    local.ros_industrial_repositories,
     local.ros_repositories,
     local.rosauth_repositories,
     local.rosbag2_repositories,

--- a/ros_industrial.tf
+++ b/ros_industrial.tf
@@ -1,0 +1,16 @@
+locals {
+  ros_industrial_team = [
+    "Levi-Armstrong",
+  ]
+  ros_industrial_repositories = [
+    "ros_industrial_cmake_boilerplate-release",
+  ]
+}
+
+module "ros_industrial_team" {
+  source       = "./modules/release_team"
+  team_name    = "ros_industrial"
+  members      = local.ros_industrial_team
+  repositories = local.ros_industrial_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
Motivated by the discussion in https://github.com/ros/rosdistro/pull/34227#issuecomment-1227540810

This PR likely does not include the complete release team or list of release repositories but it is a start from which we can add more.