### PR TITLE
Add sgvanijk to the v4l2_camera team.

### DIFF
--- a/v4l2_camera.tf
+++ b/v4l2_camera.tf
@@ -1,5 +1,6 @@
 locals {
   v4l2_camera_team = [
+    "sgvandijk",
   ]
   v4l2_camera_repositories = [
     "ros2_v4l2_camera-release",


### PR DESCRIPTION
Closes https://github.com/ros2-gbp/ros2_v4l2_camera-release/issues/1

Originally pruned in 0cd7922d3264f725065482c5ade978d3584b7d79 due to invitation timeout.