### PR TITLE
Add vision_opencv team.

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -116,6 +116,7 @@ locals {
       local.velodyne_simulator_team,
       local.velodyne_team,
       local.vision_msgs_team,
+      local.vision_opencv_team,
       local.visp_team,
       local.vrpn_team,
       local.wep21_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -115,6 +115,7 @@ locals {
     local.velodyne_repositories,
     local.velodyne_simulator_repositories,
     local.vision_msgs_repositories,
+    local.vision_opencv_repositories,
     local.visp_repositories,
     local.vrpn_repositories,
     local.wep21_repositories,

--- a/vision_opencv.tf
+++ b/vision_opencv.tf
@@ -1,0 +1,16 @@
+locals {
+  vision_opencv_team = [
+    "ijnek",
+  ]
+  vision_opencv_repositories = [
+    "vision_opencv-release",
+  ]
+}
+
+module "vision_opencv_team" {
+  source       = "./modules/release_team"
+  team_name    = "vision_opencv"
+  members      = local.vision_opencv_team
+  repositories = local.vision_opencv_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
This repository was previously only released by the ROS 2 core team.

Closes https://github.com/ros2-gbp/ros2-gbp-github-org/issues/120