### PR TITLE
Add naoqi team.

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -53,6 +53,7 @@ locals {
       local.moveit_team,
       local.mrpt2_team,
       local.mrt_cmake_modules_team,
+      local.naoqi_team,
       local.navigation_team,
       local.neobotix_team,
       local.nmea_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -52,6 +52,7 @@ locals {
     local.moveit_repositories,
     local.mrpt2_repositories,
     local.mrt_cmake_modules_repositories,
+    local.naoqi_repositories,
     local.navigation_repositories,
     local.neobotix_repositories,
     local.nmea_repositories,

--- a/naoqi.tf
+++ b/naoqi.tf
@@ -1,0 +1,26 @@
+locals {
+  naoqi_team = [
+    "Karsten1987",
+    "mbusy",
+    "mikaelarguedas",
+    "nlyubova",
+    "suryaambrose",
+    "zygopter",
+  ]
+  naoqi_repositories = [
+    "libqi-release",
+    "libqicore-release",
+    "nao_meshes-release",
+    "naoqi_bridge_msgs-release",
+    "naoqi_driver-release",
+    "pepper_meshes-release",
+  ]
+}
+
+module "naoqi_team" {
+  source       = "./modules/release_team"
+  team_name    = "naoqi"
+  members      = local.naoqi_team
+  repositories = local.naoqi_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
Closes https://github.com/ros2-gbp/ros2-gbp-github-org/issues/122

I used the team name `naoqi` rather than `ros_naoqi` since the `ros` is largely implied by the context here.