### PR TITLE
Add image_transport_plugins team.

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -38,6 +38,7 @@ locals {
       local.iceoryx_team,
       local.ifm3d_team,
       local.ijnek_team,
+      local.image_transport_plugins_team,
       local.imu_tools_team,
       local.irobot_education_team,
       local.josh_newans_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -37,6 +37,7 @@ locals {
     local.iceoryx_repositories,
     local.ifm3d_repositories,
     local.ijnek_repositories,
+    local.image_transport_plugins_repositories,
     local.imu_tools_repositories,
     local.irobot_education_repositories,
     local.josh_newans_repositories,

--- a/image_transport_plugins.tf
+++ b/image_transport_plugins.tf
@@ -1,0 +1,16 @@
+locals {
+  image_transport_plugins_team = [
+    "ijnek",
+  ]
+  image_transport_plugins_repositories = [
+    "image_transport_plugins-release",
+  ]
+}
+
+module "image_transport_plugins_team" {
+  source       = "./modules/release_team"
+  team_name    = "image_transport_plugins"
+  members      = local.image_transport_plugins_team
+  repositories = local.image_transport_plugins_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
New maintainer for image_transport_plugins.

Maintenance handover discussion - https://github.com/ros-perception/image_transport_plugins/issues/111