### PR TITLE
Adds maliput_osm and maliput_sparse to maliput repos.

### DIFF
--- a/maliput.tf
+++ b/maliput.tf
@@ -17,7 +17,9 @@ locals {
     "maliput_multilane-release",
     "maliput_object-release",
     "maliput_object_py-release",
+    "maliput_osm-release",
     "maliput_py-release",
+    "maliput_sparse-release",
   ]
 }
 


### PR DESCRIPTION
### Summary

Adding releasing repos for 2 new packages:
- https://github.com/maliput/maliput_sparse/
- https://github.com/maliput/maliput_osm/


Signed-off-by: Franco Cipollone <franco.c@ekumenlabs.com>