### PR TITLE
Add 42dot team.

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -3,6 +3,7 @@
 locals {
   non_admin_members = setsubtract(
     setunion(
+      local._42dot_team,
       local.acceleration_wg_team,
       local.ackermann_msgs_team,
       local.apex_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -1,6 +1,7 @@
 # Create memberships for the distinct set of all team members who aren't admins.
 locals {
   organization_repositories = setunion(
+    local._42dot_repositories,
     local._archived_repositories,
     local.acceleration_wg_repositories,
     local.ackermann_msgs_repositories,

--- a/42dot.tf
+++ b/42dot.tf
@@ -1,0 +1,16 @@
+locals {
+  _42dot_team = [
+    "huchijwk",
+  ]
+  _42dot_repositories = [
+    "42dot-release",
+  ]
+}
+
+module "_42dot_team" {
+  source       = "./modules/release_team"
+  team_name    = "42dot"
+  members      = local._42dot_team
+  repositories = local._42dot_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
Since Terraform identifiers cannot start with numerals they are prefixed with a _.

Closes #141 