### PR TITLE
Add explicit depends on for teams which don't have it set.

### DIFF
--- a/foxglove_bridge.tf
+++ b/foxglove_bridge.tf
@@ -16,4 +16,5 @@ module "foxglove_bridge_team" {
   team_name    = "foxglove_bridge"
   members      = local.foxglove_bridge_team
   repositories = local.foxglove_bridge_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }

--- a/maliput.tf
+++ b/maliput.tf
@@ -28,4 +28,5 @@ module "maliput_team" {
   team_name    = "maliput"
   members      = local.maliput_team
   repositories = local.maliput_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
 }


### PR DESCRIPTION
This prevents race conditions by ensuring that repositories and members are created before creating the team association.