### PR TITLE
Fix misnamed repository.

### DIFF
--- a/42dot.tf
+++ b/42dot.tf
@@ -3,7 +3,7 @@ locals {
     "huchijwk",
   ]
   _42dot_repositories = [
-    "42dot-release",
+    "foros-release",
   ]
 }
 


### PR DESCRIPTION
The release repository was accidentally given the team name in haste.

Closes #152 