### PR TITLE
Updates to wep21 release team repositories.

### DIFF
--- a/00-archived.tf
+++ b/00-archived.tf
@@ -6,6 +6,7 @@ locals {
     "console_bridge-release",
     "gmock_vendor-release",
     "gtest_vendor-release",
+    "linear_sum_assignment-release",
     "navigation-release",
     "osrf_testings_tools_cpp-release",
     "poco_vendor-release",

--- a/wep21.tf
+++ b/wep21.tf
@@ -4,7 +4,7 @@ locals {
   ]
   wep21_repositories = [
     "bag2_to_image-release",
-    "linear_sum_assignment-release",
+    "turbojpeg_compressed_image_transport-release",
   ]
 }
 


### PR DESCRIPTION
* Archive linear_sum_assignment release repository.
* Add [turbojpeg_compressed_image_transport](https://github.com/wep21/turbojpeg_compressed_image_transport) release repository.