### PR TITLE
Add dynamixel_community release team.

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -21,6 +21,7 @@ locals {
       local.cyclonedds_team,
       local.diagnostics_team,
       local.dolly_team,
+      local.dynamixel_community_team,
       local.eigenpy_team,
       local.fastcdr_team,
       local.fictionlab_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -20,6 +20,7 @@ locals {
     local.cyclonedds_repositories,
     local.diagnostics_repositories,
     local.dolly_repositories,
+    local.dynamixel_community_repositories,
     local.eigenpy_repositories,
     local.fastcdr_repositories,
     local.fictionlab_repositories,

--- a/dynamixel_community.tf
+++ b/dynamixel_community.tf
@@ -1,0 +1,17 @@
+locals {
+  dynamixel_community_team = [
+    "ijnek",
+    "youtalk",
+  ]
+  dynamixel_community_repositories = [
+    "dynamixel_hardware-release",
+  ]
+}
+
+module "dynamixel_community_team" {
+  source       = "./modules/release_team"
+  team_name    = "dynamixel_community"
+  members      = local.dynamixel_community_team
+  repositories = local.dynamixel_community_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
Based on the discussion in https://github.com/ros/rosdistro/pull/35400 and https://github.com/dynamixel-community/dynamixel_hardware/issues/46

@ijnek and @youtalk if this looks alright to you I will mirror the current dynamixel_hardware-release repository into ros2-gbp and the current repository can then be archived or deleted. Normally I would not suggest deletion at all but since the original release repository is not (to my knowledge) used in any ROS release it does not need to be preserved once mirrored.