### PR TITLE
Ignore projects on repositories.

### DIFF
--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -154,6 +154,7 @@ resource "github_repository" "repositories" {
       etag,
       has_downloads,
       has_issues,
+      has_projects,
       has_wiki,
       homepage_url,
       vulnerability_alerts
@@ -177,6 +178,7 @@ resource "github_repository" "ros2-gbp-github-org" {
       description,
       etag,
       has_downloads,
+      has_projects,
       has_issues,
       has_wiki,
       vulnerability_alerts


### PR DESCRIPTION
Cuts down on noise. At some point we can revisit these and potentially disable unused features explicitly for release repositories as a vector against abuse/misuse.