### PR TITLE
Rename ignition_*_vendor to gz_*_vendor

### DIFF
--- a/gazebo.tf
+++ b/gazebo.tf
@@ -10,10 +10,10 @@ locals {
   gazebo_repositories = [
     "gazebo_ros2_control-release",
     "gazebo_ros_pkgs-release",
-    "ign_rviz-release",
-    "ign_ros2_control-release",
     "gz_cmake2_vendor-release",
     "gz_math6_vendor-release",
+    "ign_ros2_control-release",
+    "ign_rviz-release",
     "ros_ign-release",
   ]
 }

--- a/gazebo.tf
+++ b/gazebo.tf
@@ -12,8 +12,8 @@ locals {
     "gazebo_ros_pkgs-release",
     "ign_rviz-release",
     "ign_ros2_control-release",
-    "ignition_cmake2_vendor-release",
-    "ignition_math6_vendor-release",
+    "gz_cmake2_vendor-release",
+    "gz_math6_vendor-release",
     "ros_ign-release",
   ]
 }


### PR DESCRIPTION
Part of the broader renaming scheme.

https://github.com/ros2-gbp/ignition_math6_vendor-release needs to be renamed to 
https://github.com/ros2-gbp/gz_math6_vendor-release

https://github.com/ros2-gbp/ignition_cmake2_vendor-release needs to be renamed to 
https://github.com/ros2-gbp/gz_cmake2_vendor-release