### PR TITLE
add knorth55 in usb_cam team

### DIFF
--- a/usb_cam.tf
+++ b/usb_cam.tf
@@ -1,6 +1,7 @@
 locals {
   usb_cam_team = [
     "flynneva",
+    "knorth55",
   ]
   usb_cam_repositories = [
     "usb_cam-release",


### PR DESCRIPTION
I want to make a release of `usb_cam`, so I want to have the access to `usb_cam-release` repo.
The maintainer of `usb_cam` @flynneva requested me to open a PR to add me in `usb_cam` team in this repo.
https://github.com/ros-drivers/usb_cam/issues/203#issuecomment-1464753039