### PR TITLE
Adds maliput_ros-release repo to maliput familiy

### DIFF
--- a/maliput.tf
+++ b/maliput.tf
@@ -19,9 +19,7 @@ locals {
     "maliput_object_py-release",
     "maliput_osm-release",
     "maliput_py-release",
-    "maliput_ros",
-    "maliput_ros_interfaces",
-    "maliput_ros_translation",
+    "maliput_ros-release",
     "maliput_sparse-release",
     "maliput_viz-release",
   ]


### PR DESCRIPTION
### Summary

Adds:
 + `maliput_ros-release` release repo to `maliput` family.
 
Removes:
 - `maliput_ros`, `maliput_ros_interfaces` and `maliput_ros_translation` from `maliput` family.
 
 ### Related
 https://github.com/ros/rosdistro/pull/36883