### PR TITLE
Reverting b85bc6d temporarily.

### DIFF
--- a/rplidar_ros.tf
+++ b/rplidar_ros.tf
@@ -1,8 +1,6 @@
 locals {
   rplidar_ros_team = [
-    "WubinXia",
     "allenh1",
-    "deyouslamtec",
   ]
   rplidar_ros_repositories = [
     "rplidar_ros-release",


### PR DESCRIPTION
There is a discrepancy between the ROS 2 and ROS 1 sources for this package.