### PR TITLE
Update github provider version.

### DIFF
--- a/00-provider.tf
+++ b/00-provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "4.19.2"
+      version = "5.34.0"
     }
   }
 }

--- a/modules/release_team/main.tf
+++ b/modules/release_team/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "5.34.0"
+    }
+  }
+}
+
 resource "github_team" "release_team" {
   name                      = var.team_name
   description               = "ROS release managers for the ${var.team_name} project"


### PR DESCRIPTION
In addition to updating this provider version I have also run

    terraform state replace-provider hashicorp/github integrations/github

in order to move all state to the canonical provider. This also protects from unintentional provider version mismatch.

To complete the transition and fully remove the other provider, I'll need to complete a deployment so that no current state or current configuration uses the old provider unintentionally.

I may also need to update data sources manually which may not be covered by the provider-replacement, I can't quite tell.