### PR TITLE
Added point cloud transport team and release repositories

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -93,6 +93,7 @@ locals {
     local.pinocchio_team,
     local.plansys2_team,
     local.plotjuggler_team,
+    local.point_cloud_transport_team,
     local.py_trees_team,
     local.rclc_team,
     local.rcpputils_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -93,6 +93,7 @@ locals {
     local.pinocchio_repositories,
     local.plansys2_repositories,
     local.plotjuggler_repositories,
+    local.point_cloud_transport_repositories,
     local.py_trees_repositories,
     local.rclc_repositories,
     local.rcpputils_repositories,

--- a/point_cloud_transport.tf
+++ b/point_cloud_transport.tf
@@ -1,0 +1,19 @@
+locals {
+  point_cloud_transport_team = [
+    "ahcorde",
+    "john-maidbot"
+  ]
+  point_cloud_transport_repositories = [
+    "point_cloud_transport-release",
+    "point_cloud_transport_plugins-release",
+    "point_cloud_transport_tutorial-release",
+  ]
+}
+
+module "point_cloud_transport_team" {
+  source       = "./modules/release_team"
+  team_name    = "point_cloud_transport"
+  members      = local.point_cloud_transport_team
+  repositories = local.point_cloud_transport_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
Added a team for point cloud transport team and release repositories 

The packages are already merged in [rosdistro](https://github.com/ros/rosdistro/pull/38422) but only the source entry.  The packages meet REP-144 naming standards, next step we should open the release repositories.