### PR TITLE
Prune team member who has not accepted multiple invitations.

### DIFF
--- a/eclipse_ecal.tf
+++ b/eclipse_ecal.tf
@@ -1,6 +1,5 @@
 locals {
   eclipse_ecal_team = [
-    "FlorianReimold",
     "wep21",
   ]
   eclipse_ecal_repositories = [


### PR DESCRIPTION
GitHub invitations expire after seven days. Whenever an invitation expires without being accepted, our terraform scripts will create a new invitation.

In the interest of not sending continual invitations and adding to the background noise of notifications I'm  pruning organization members who have not accepted multiple rounds of invitations.

It's always possible to revert these changes and grant access again if needed in the future.

Another batch of invitation has just gone out. If that invitation expires, I'll proceed with merging this PR.