### PR TITLE
Adding the Open Dynamic Robot Initiative (ODRI) team.

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -81,6 +81,7 @@ locals {
     local.numsr_team,
     local.object_analytics_team,
     local.octomap_team,
+    local.odri_team,
     local.ompl_team,
     local.openni2_camera_team,
     local.ouster_drivers_team,
@@ -168,4 +169,3 @@ resource "github_membership" "members" {
   username = each.value
   role     = contains(local.ros_admins, each.value) ? "admin" : "member"
 }
-

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -81,6 +81,7 @@ locals {
     local.numsr_repositories,
     local.object_analytics_repositories,
     local.octomap_repositories,
+    local.odri_repositories,
     local.ompl_repositories,
     local.openni2_camera_repositories,
     local.ouster_drivers_repositories,

--- a/odri.tf
+++ b/odri.tf
@@ -1,0 +1,18 @@
+locals {
+  odri_team = [
+    "olivier-stasse",
+    "nim65s",
+    "MaximilienNaveau",
+  ]
+  odri_repositories = [
+    "odri_master_board_sdk-release",
+  ]
+}
+
+module "odri_team" {
+  source       = "./modules/release_team"
+  team_name    = "odri"
+  members      = local.odri_team
+  repositories = local.odri_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
This PR is asking the creation of the ODRI team.
The intend is to release repositories related to the robots Solo, Bolt and others created by the ODRI consortium.
(https://github.com/open-dynamic-robot-initiative/)

Would it be possible to have also a new repository: odri_master_board_sdk-release 
The original one has naming issues that we would like to fix in this release repository. 
(As we understood that this is the correct way of fixing this kind of problems).


