### PR TITLE
Revert #322 restoring team member.

### DIFF
--- a/naoqi.tf
+++ b/naoqi.tf
@@ -3,6 +3,7 @@ locals {
     "Karsten1987",
     "mbusy",
     "mikaelarguedas",
+    "nlyubova",
   ]
   naoqi_repositories = [
     "libqi-release",


### PR DESCRIPTION
This was committed in spite of the fact that the removed member actually did accept the invitation.

This reverts commit 69fd5593eaea542224d486ae56b8864fd7069a36.