### PR TITLE
Added rqt gauges to rqt.tf

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -146,6 +146,7 @@ locals {
     local.tooling_wg_team,
     local.tracing_team,
     local.transport_drivers_team,
+    local.tri_team,
     local.tsid_team,
     local.turtlebot4_team,
     local.tuw_robotics_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -144,6 +144,7 @@ locals {
     local.tooling_wg_repositories,
     local.tracing_repositories,
     local.transport_drivers_repositories,
+    local.tri_repositories,
     local.tsid_repositories,
     local.turtlebot4_repositories,
     local.tuw_robotics_repositories,

--- a/rqt.tf
+++ b/rqt.tf
@@ -4,12 +4,10 @@ locals {
     "arne48",
     "mlautman",
     "srishtidh",
-    "ahcorde",
   ]
   rqt_repositories = [
     "rqt_action-release",
     "rqt_console-release",
-    "rqt_gauges-release",
     "rqt_image_view-release",
     "rqt_moveit-release",
     "rqt_msg-release",

--- a/rqt.tf
+++ b/rqt.tf
@@ -4,10 +4,12 @@ locals {
     "arne48",
     "mlautman",
     "srishtidh",
+    "ahcorde",
   ]
   rqt_repositories = [
     "rqt_action-release",
     "rqt_console-release",
+    "rqt_gauges-release",
     "rqt_image_view-release",
     "rqt_moveit-release",
     "rqt_msg-release",

--- a/tri.tf
+++ b/tri.tf
@@ -1,7 +1,7 @@
 locals {
   tri_team = [
     "ahcorde",
-    "caguero"
+    "caguero",
   ]
   tri_repositories = [
     "rqt_gauges-release",

--- a/tri.tf
+++ b/tri.tf
@@ -1,0 +1,17 @@
+locals {
+  tri_team = [
+    "ahcorde",
+    "caguero"
+  ]
+  tri_repositories = [
+    "rqt_gauges-release",
+  ]
+}
+
+module "tri_team" {
+  source       = "./modules/release_team"
+  team_name    = "tri"
+  members      = local.tri_team
+  repositories = local.tri_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
Added rqt gauges to rqt.tf

The packages are already merged in [rosdistro](https://github.com/ros/rosdistro/pull/39350) but only the source entry.  The packages meet REP-144 naming standards, next step we should open the release repositories.

Repository: https://github.com/ToyotaResearchInstitute/gauges2.git