### PR TITLE
update maintainers for image_pipeline

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -176,6 +176,7 @@ locals {
     local.velodyne_team,
     local.vision_msgs_team,
     local.vision_opencv_team,
+    local.vision_team,
     local.visp_team,
     local.vrpn_team,
     local.wep21_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -174,6 +174,7 @@ locals {
     local.velodyne_simulator_repositories,
     local.vision_msgs_repositories,
     local.vision_opencv_repositories,
+    local.vision_repositories,
     local.visp_repositories,
     local.vrpn_repositories,
     local.wep21_repositories,

--- a/navigation.tf
+++ b/navigation.tf
@@ -3,10 +3,8 @@ locals {
     "JWhitleyWork",
     "SteveMacenski",
     "paulbovbel",
-    "ahcorde",
   ]
   navigation_repositories = [
-    "image_pipeline-release",
     "navigation-release",
     "navigation2-release",
     "navigation_msgs-release",

--- a/navigation.tf
+++ b/navigation.tf
@@ -3,6 +3,7 @@ locals {
     "JWhitleyWork",
     "SteveMacenski",
     "paulbovbel",
+    "ahcorde",
   ]
   navigation_repositories = [
     "image_pipeline-release",

--- a/vision.tf
+++ b/vision.tf
@@ -1,0 +1,17 @@
+locals {
+  vision_team = [
+    "ahcorde",
+    "mikeferguson",
+  ]
+  vision_repositories = [
+    "image_pipeline-release",
+  ]
+}
+
+module "vision_team" {
+  source       = "./modules/release_team"
+  team_name    = "vision"
+  members      = local.vision_team
+  repositories = local.vision_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
I would like to make an image_pipeline release on Humble, Iron and Rolling. Adding my self as a maintainers to speed up the process. 

By the way, I'm also the maintainer of `image_common`, which is a core package, but I don't understand why this package is under `navigation`. Maybe something like `vision` makes more sense?