### PR TITLE
Add fields2cover release team and repository.

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -42,6 +42,7 @@ locals {
     local.fastcdr_team,
     local.ffmpeg_image_transport_team,
     local.fictionlab_team,
+    local.fields2cover_team,
     local.flexbe_team,
     local.fmi_team,
     local.fogros2_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -42,6 +42,7 @@ locals {
     local.fastcdr_repositories,
     local.ffmpeg_image_transport_repositories,
     local.fictionlab_repositories,
+    local.fields2cover_repositories,
     local.flexbe_repositories,
     local.fmi_repositories,
     local.fogros2_repositories,

--- a/fields2cover.tf
+++ b/fields2cover.tf
@@ -1,0 +1,16 @@
+locals {
+  fields2cover_team = [
+    "Gonzalo-Mier",
+  ]
+  fields2cover_repositories = [
+    "fields2cover-release",
+  ]
+}
+
+module "fields2cover_team" {
+  source       = "./modules/release_team"
+  team_name    = "fields2cover"
+  members      = local.fields2cover_team
+  repositories = local.fields2cover_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
I'm importing this release repository ahead of the upcoming Rolling transition to 24.04.
All artifacts from the previous release repository have been imported into this one and the maintainer of the package has been included in the release team.