### PR TITLE
Add pal_statistics release repository.

### DIFF
--- a/pal_robotics.tf
+++ b/pal_robotics.tf
@@ -7,6 +7,7 @@ locals {
   ]
   pal_robotics_repositories = [
     "backward_ros-release",
+    "pal_statistics-release",
   ]
 }
 


### PR DESCRIPTION
Imported from the previous release repository using `git push --mirror`.

Archiving but not deleting the previous release repository is recommended to prevent future releases from being released in it.