### PR TITLE
Set bloom config branch as default for all ros2-gbp release reposiories.

### DIFF
--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -198,6 +198,13 @@ locals {
   )
 }
 
+resource "github_branch_default" "bloom_branch" {
+  for_each = github_repository.repositories
+
+  repository = each.value.name
+  branch     = "master"
+}
+
 resource "github_repository" "repositories" {
   for_each = local.organization_repositories
 


### PR DESCRIPTION
In order to deploy this I've done a giant import of the current default branch state for all current ros2-gbp repositories.

I have a snapshot of the state prior to restore to if this PR is not merged.

Since this uses the github_repository.repositories resource the terraform dependency will make certain that repositories are created before a default branch is set but I'm not entirely sure how application will work for a just-initialized repository. Worst case scenario there might be a double bounce where the default branch is set in the second run after a repository is created... or it will fail unless we create an initial touch commit on the bloom config branch.