### PR TITLE
Increase parallelism of plan operations.

### DIFF
--- a/bin/plan
+++ b/bin/plan
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-exec terraform plan -out plan.out | tee plan.txt
+PARALLELISM=${PARALLELISM:=128}
+exec terraform plan -parallelism=$PARALLELISM -out plan.out | tee plan.txt


### PR DESCRIPTION
I'm still finding a sweet spot here between GitHub throttling and the terraform scheduler but given how big the project is and the fact that GitHub API requests for each repository and member are all fairly independent, increasing beyond the default parallelism is well warranted, it's just a matter of finding a good default. Either absolute or relative to `nproc`.