### PR TITLE
Add a template release repository and use it for creating new release repos.

### DIFF
--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -211,6 +211,13 @@ resource "github_repository" "repositories" {
   archived     = contains(local._archived_repositories, each.value)
   visibility   = "public"
   has_projects = false
+
+  template {
+    owner                = "ros2-gbp"
+    repository           = "release-repository-template"
+    include_all_branches = true
+  }
+
   lifecycle {
     # Plans that destroy repository releases will delete the repository on
     # GitHub and that shouldn't be done in the normal course of operation.
@@ -225,6 +232,7 @@ resource "github_repository" "repositories" {
       has_issues,
       has_wiki,
       homepage_url,
+      template,
       vulnerability_alerts
     ]
   }

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -207,9 +207,10 @@ resource "github_branch_default" "bloom_branch" {
 resource "github_repository" "repositories" {
   for_each = local.organization_repositories
 
-  name       = each.value
-  archived   = contains(local._archived_repositories, each.value)
-  visibility = "public"
+  name         = each.value
+  archived     = contains(local._archived_repositories, each.value)
+  visibility   = "public"
+  has_projects = false
   lifecycle {
     # Plans that destroy repository releases will delete the repository on
     # GitHub and that shouldn't be done in the normal course of operation.
@@ -222,7 +223,6 @@ resource "github_repository" "repositories" {
       etag,
       has_downloads,
       has_issues,
-      has_projects,
       has_wiki,
       homepage_url,
       vulnerability_alerts
@@ -233,8 +233,9 @@ resource "github_repository" "repositories" {
 # No team manages this repository.
 # It is writable by organization admins only.
 resource "github_repository" "ros2-gbp-github-org" {
-  name       = "ros2-gbp-github-org"
-  visibility = "public"
+  name         = "ros2-gbp-github-org"
+  visibility   = "public"
+  has_projects = false
   lifecycle {
     # Plans that destroy repository releases will delete the repository on
     # GitHub and that shouldn't be done in the normal course of operation.
@@ -246,7 +247,6 @@ resource "github_repository" "ros2-gbp-github-org" {
       description,
       etag,
       has_downloads,
-      has_projects,
       has_issues,
       has_wiki,
       vulnerability_alerts

--- a/00-ros2_gbp.tf
+++ b/00-ros2_gbp.tf
@@ -25,6 +25,28 @@ resource "github_repository" "dotgithub" {
   }
 }
 
+resource "github_repository" "release-repository-template" {
+  name         = "release-repository-template"
+  visibility   = "public"
+  is_template  = true
+  has_projects = false
+  lifecycle {
+    # Plans that destroy repository releases will delete the repository on
+    # GitHub and that shouldn't be done in the normal course of operation.
+    prevent_destroy = true
+    # Ignore fields that are not set or managed by this terraform project
+    # to prevent unecessary drift.
+    ignore_changes = [
+      allow_merge_commit,
+      description,
+      has_downloads,
+      has_issues,
+      has_wiki,
+      vulnerability_alerts
+    ]
+  }
+}
+
 resource "github_team" "docs_team" {
   name                      = "ros2-gbp-docs"
   description               = "ros2-gbp documentation contributors"


### PR DESCRIPTION
The one downside to this approach is that it slightly complicates the act of mirroring in an external release repository by awkwardly putting a commit in place (which `git push --mirror` will fearlessly destroy).

However in order to prevent a possible race condition where I've given the maintainers access but have not yet mirrored the repository data, I usually create the mirror repos by hand, perform the mirror push, and then import them into terraform rather than letting them be created so I don't think this is a blocker to proceeding.

However, https://github.com/integrations/terraform-provider-github/issues/2090 is going to create consistent spam in the terraform plan until I can resolve it upstream or resort to heinous behavior to remove that state for repositories that are not new to the current terraform run.