### PR TITLE
Add in flir_camera_driver module.

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -44,6 +44,7 @@ locals {
     local.fields2cover_team,
     local.filters_team,
     local.flexbe_team,
+    local.flir_camera_driver_team,
     local.fmi_team,
     local.fogros2_team,
     local.fortefibre_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -44,6 +44,7 @@ locals {
     local.fields2cover_repositories,
     local.filters_repositories,
     local.flexbe_repositories,
+    local.flir_camera_driver_repositories,
     local.fmi_repositories,
     local.fogros2_repositories,
     local.fortefibre_repositories,

--- a/flir_camera_driver.tf
+++ b/flir_camera_driver.tf
@@ -1,0 +1,16 @@
+locals {
+  flir_camera_driver_team = [
+    "berndpfrommer",
+  ]
+  flir_camera_driver_repositories = [
+    "flir_camera_driver-release",
+  ]
+}
+
+module "flir_camera_driver_team" {
+  source       = "./modules/release_team"
+  team_name    = "flir_camera_driver"
+  members      = local.flir_camera_driver_team
+  repositories = local.flir_camera_driver_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
The repository already exists, but this is needed to give permissions to the maintainer.

@nuclearsandwich This is fallout from https://github.com/ros/rosdistro/pull/40674