### PR TITLE
Update autoware's team and repositories

### DIFF
--- a/autoware.tf
+++ b/autoware.tf
@@ -1,11 +1,18 @@
 locals {
   autoware_team = [
+    "esteve",
     "mitsudome-r",
+    "youtalk",
   ]
 
   autoware_repositories = [
     "acado_vendor-release",
+    "autoware_adapi_msgs-release",
     "autoware_auto_msgs-release",
+    "autoware_cmake-release",
+    "autoware_lanelet2_extension-release",
+    "autoware_msgs-release",
+    "autoware_utils-release",
     "qpoases_vendor-release",
     "ros2_socketcan-release",
     "tvm_vendor-release",


### PR DESCRIPTION
This PR has updated `autoware.tf` as follows:
- Add @esteve and @youtalk to `autoware_team`
- Add `autoware_adapi_msgs-release`, `autoware_cmake-release`,` autoware_lanelet2_extension-release`, `autoware_msgs-release`, and `autoware_utils-release` to `autoware_repositories`

Please create above release reposities.