### PR TITLE
Add rmw_zenoh release to ROS 2 team repositories.

### DIFF
--- a/00-ros2_core.tf
+++ b/00-ros2_core.tf
@@ -141,6 +141,7 @@ locals {
     "rmw_dds_common-release",
     "rmw_fastrtps-release",
     "rmw_implementation-release",
+    "rmw_zenoh-release",
     "ros1_bridge-release",
     "ros2_message_filters-release",
     "ros2cli-release",


### PR DESCRIPTION
Resolves #494.