### PR TITLE
Add xmfcx to autoware_team

### DIFF
--- a/autoware.tf
+++ b/autoware.tf
@@ -2,8 +2,8 @@ locals {
   autoware_team = [
     "esteve",
     "mitsudome-r",
-    "youtalk",
     "xmfcx",
+    "youtalk",
   ]
 
   autoware_repositories = [

--- a/autoware.tf
+++ b/autoware.tf
@@ -3,6 +3,7 @@ locals {
     "esteve",
     "mitsudome-r",
     "youtalk",
+    "xmfcx",
   ]
 
   autoware_repositories = [


### PR DESCRIPTION
I'm adding myself to the `autoware_team`.

Following up from:
- https://github.com/autowarefoundation/ros2_socketcan/pull/46#issuecomment-2184053913

I have admin rights to the https://github.com/autowarefoundation organization.

@mitsudome-r can you confirm since you are also in the team?