### PR TITLE
Add snt_arg release repositories.

### DIFF
--- a/snt_arg.tf
+++ b/snt_arg.tf
@@ -5,10 +5,13 @@ locals {
   ]
   snt_arg_repositories = [
     "fast_gicp-release",
+    "lidar_situational_graphs-release",
     "ndt_omp-release",
     "situational_graphs_dataset-release",
     "situational_graphs_msgs-release",
     "situational_graphs_reasoning-release",
+    "situational_graphs_reasoning_msgs-release",
+    "situational_graphs_wrapper-release",
     "unitree_ros-release",
   ]
 }


### PR DESCRIPTION
Due to a mixup, the previous change #548 added situational_graphs_reasoning instead of situational_graphs_reasoning_msgs. This change adds situational_graphs_reasoning_msgs instead of
situational_graphs_reasoning to square things up.

Resolves #543.