### PR TITLE
Add soblin to autoware_team

### DIFF
--- a/autoware.tf
+++ b/autoware.tf
@@ -4,6 +4,7 @@ locals {
     "mitsudome-r",
     "xmfcx",
     "youtalk",
+    "soblin",
   ]
 
   autoware_repositories = [


### PR DESCRIPTION
I'm adding myself to `autoware_team` as a active development member of 
https://github.com/autowarefoundation/autoware_lanelet2_extension

@youtalk @mitsudome-r can you approve this as a co-member ?
