### PR TITLE
Fix typo in username

### DIFF
--- a/turtlebot4.tf
+++ b/turtlebot4.tf
@@ -1,6 +1,6 @@
 locals {
   turtlebot4_team = [
-    "civerach-cpr",
+    "civerachb-cpr",
     "kscottz",
     "roni-kreinin",
     "tfoote",


### PR DESCRIPTION
New turtlebot4 release team member is `civerachb-cpr`, not `civerach-cpr`.  Fixes unnoticed typo in #607.