### PR TITLE
Add sea-bass to moveit team

### DIFF
--- a/moveit.tf
+++ b/moveit.tf
@@ -5,6 +5,7 @@ locals {
     "henningkayser",
     "pac48",
     "rhaschke",
+    "sea-bass",
     "sjahr",
     "tylerjw",
     "v4hn",


### PR DESCRIPTION
I was already on the `picknik` team, but not on the `moveit` one. I just found this out by trying to bloom `srdfdom` and having insufficient permissions.