### PR TITLE
Create teleop_team and add 'Noel215' to teleop_team and twist_mux_team

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -181,6 +181,7 @@ locals {
     local.system_modes_team,
     local.teamspatzenhirn_team,
     local.techmagic_team,
+    local.teleop_team,
     local.tf_transformations_team,
     local.the_construct_team,
     local.tier4_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -179,6 +179,7 @@ locals {
     local.system_modes_repositories,
     local.teamspatzenhirn_repositories,
     local.techmagic_repositories,
+    local.teleop_repositories,
     local.tf_transformations_repositories,
     local.the_construct_repositories,
     local.tier4_repositories,

--- a/control.tf
+++ b/control.tf
@@ -12,7 +12,6 @@ locals {
     "realtime_tools-release",
     "ros2_control-release",
     "ros2_controllers-release",
-    "teleop_tools-release",
   ]
 }
 

--- a/teleop.tf
+++ b/teleop.tf
@@ -1,6 +1,7 @@
 locals {
   teleop_team = [
     "bmagyar",
+    "Noel215",
   ]
   teleop_repositories = [
     "teleop_tools-release",

--- a/teleop.tf
+++ b/teleop.tf
@@ -1,7 +1,7 @@
 locals {
   teleop_team = [
-    "bmagyar",
     "Noel215",
+    "bmagyar",
   ]
   teleop_repositories = [
     "teleop_tools-release",

--- a/teleop.tf
+++ b/teleop.tf
@@ -1,0 +1,16 @@
+locals {
+  teleop_team = [
+    "bmagyar",
+  ]
+  teleop_repositories = [
+    "teleop_tools-release",
+  ]
+}
+
+module "teleop_team" {
+  source       = "./modules/release_team"
+  team_name    = "teleop"
+  members      = local.teleop_team
+  repositories = local.teleop_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}

--- a/twist_mux.tf
+++ b/twist_mux.tf
@@ -1,6 +1,7 @@
 locals {
   twist_mux_team = [
     "bmagyar",
+    "Noel215",
   ]
   twist_mux_repositories = [
     "twist_mux-release",

--- a/twist_mux.tf
+++ b/twist_mux.tf
@@ -1,7 +1,7 @@
 locals {
   twist_mux_team = [
-    "bmagyar",
     "Noel215",
+    "bmagyar",
   ]
   twist_mux_repositories = [
     "twist_mux-release",


### PR DESCRIPTION
This PR splits the `teleop_tools-release` repository from the `control_team` into a new `teleop_team`.

Also adds myself as part of the `teleop_team` and the `twist_mux_team`.