### PR TITLE
hpp_fcl: add coal-release

### DIFF
--- a/hpp_fcl.tf
+++ b/hpp_fcl.tf
@@ -6,6 +6,7 @@ locals {
     "wxmerkt",
   ]
   hpp_fcl_repositories = [
+    "coal-release",
     "hpp_fcl-release",
   ]
 }


### PR DESCRIPTION
Hi,

hpp-fcl was renamed coal for v3.0.0.
Therefore, I think we'll need a new release repository for it.
