### PR TITLE
Restore accidentally overridden release team members and repositories.

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -234,7 +234,6 @@ locals {
     local.visp_team,
     local.vrpn_team,
     local.wasp_research_group_team,
-    local.wasp_research_group_team,
     local.wep21_team,
     local.xacro_team,
     local.yukkysaito_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -232,7 +232,6 @@ locals {
     local.visp_repositories,
     local.vrpn_repositories,
     local.wasp_research_group_repositories,
-    local.wasp_research_group_repositories,
     local.wep21_repositories,
     local.xacro_repositories,
     local.yukkysaito_repositories,

--- a/wasp_research_group.tf
+++ b/wasp_research_group.tf
@@ -1,9 +1,12 @@
 locals {
   wasp_research_group_team = [
+    "MFernandezCarmona",
     "ajtudela",
   ]
   wasp_research_group_repositories = [
+    "laser_segmentation-release",
     "sicks300_ros2-release",
+    "slg_msgs-release",
   ]
 }
 


### PR DESCRIPTION
The issue listed this as a "new" release team and I didn't double check as my scripts overwrote the existing team.
