### PR TITLE
Add ai_worker release repository

### DIFF
--- a/robotis.tf
+++ b/robotis.tf
@@ -4,6 +4,7 @@ locals {
     "robotpilot",
   ]
   robotis_repositories = [
+    "ai_worker-release",
     "dynamixel_hardware_interface-release",
     "dynamixel_interfaces-release",
     "dynamixel_sdk-release",


### PR DESCRIPTION
We are currently preparing to release the following new ROS 2 package:
- https://github.com/ROBOTIS-GIT/ai_worker

A related pull request has also been submitted to the rosdistro repository:
- https://github.com/ros/rosdistro/pull/45165