### PR TITLE
Add aruco_ros release repository to existing pal_robotics team.

### DIFF
--- a/pal_robotics.tf
+++ b/pal_robotics.tf
@@ -6,6 +6,7 @@ locals {
     "saikishor",
   ]
   pal_robotics_repositories = [
+    "aruco_ros-release",
     "backward_ros-release",
     "pal_statistics-release",
   ]


### PR DESCRIPTION
This repository has been mirrored into ros2-gbp ahead of the ROS 2 Kilted release.

FYI @saikishor

My recommendation is actually to use the ros2-gbp repository for all releases going forward (all artifacts from the pal-gbp repository have been mirrored here) and archive the pal-gbp repository to prevent using it accidentally.