### PR TITLE
Add py_binding_tools release team and repositories.

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -147,6 +147,7 @@ locals {
     local.plotjuggler_team,
     local.point_cloud_transport_team,
     local.pradyum_group_team,
+    local.py_binding_tools_team,
     local.py_trees_team,
     local.rclc_team,
     local.rcpputils_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -147,6 +147,7 @@ locals {
     local.plotjuggler_repositories,
     local.point_cloud_transport_repositories,
     local.pradyum_group_repositories,
+    local.py_binding_tools_repositories,
     local.py_trees_repositories,
     local.rclc_repositories,
     local.rcpputils_repositories,

--- a/py_binding_tools.tf
+++ b/py_binding_tools.tf
@@ -1,0 +1,16 @@
+locals {
+  py_binding_tools_team = [
+    "rhaschke",
+  ]
+  py_binding_tools_repositories = [
+    "py_binding_tools-release",
+  ]
+}
+
+module "py_binding_tools_team" {
+  source       = "./modules/release_team"
+  team_name    = "py_binding_tools"
+  members      = local.py_binding_tools_team
+  repositories = local.py_binding_tools_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
This repository has been mirrored into ros2-gbp ahead of the ROS 2 Kilted release.