### PR TITLE
Add coin_d4_driver package

### DIFF
--- a/robotis.tf
+++ b/robotis.tf
@@ -5,6 +5,7 @@ locals {
   ]
   robotis_repositories = [
     "ai_worker-release",
+    "coin_d4_driver-release",
     "dynamixel_hardware_interface-release",
     "dynamixel_interfaces-release",
     "dynamixel_sdk-release",


### PR DESCRIPTION
We are currently preparing to release the following new ROS 2 package:
- https://github.com/ROBOTIS-GIT/coin_d4_driver

The corresponding pull requests have also been committed to the rosdistro repository:
- https://github.com/ros/rosdistro/pull/46423
- https://github.com/ros/rosdistro/pull/46422
- https://github.com/ros/rosdistro/pull/46421