### PR TITLE
Update autoware.tf to create autoware_core-release 

### DIFF
--- a/autoware.tf
+++ b/autoware.tf
@@ -12,6 +12,7 @@ locals {
     "autoware_adapi_msgs-release",
     "autoware_auto_msgs-release",
     "autoware_cmake-release",
+    "autoware_core-release",
     "autoware_internal_msgs-release",
     "autoware_lanelet2_extension-release",
     "autoware_msgs-release",


### PR DESCRIPTION
This PR has updated autoware.tf to append `autoware_core-release` to autoware_repositories
Please create above release repository.

