### PR TITLE
eigenpy: add nanoeigenpy-release

### DIFF
--- a/eigenpy.tf
+++ b/eigenpy.tf
@@ -6,6 +6,7 @@ locals {
   ]
   eigenpy_repositories = [
     "eigenpy-release",
+    "nanoeigenpy-release",
   ]
 }
 


### PR DESCRIPTION
Hi,

Eigenpy is currently being rewritten with nanobind instead of boost python.
Therefore, I think we'll need a new release repository for it.

The source repository has already been accepted in https://github.com/ros/rosdistro/pull/45744