### PR TITLE
Add the kdl_parser_py release repository.

### DIFF
--- a/00-ros2_core.tf
+++ b/00-ros2_core.tf
@@ -115,6 +115,7 @@ locals {
     "interactive_markers-release",
     "joint_state_publisher-release",
     "joystick_drivers-release",
+    "kdl_parser_py-release",
     "laser_geometry-release",
     "laser_proc-release",
     "libyaml_vendor-release",


### PR DESCRIPTION
We just add it to the "additional" repositories for core, since it is being split out of a core repository (kdl_parser).