### PR TITLE
Update foxglove_bridge release team membership

### DIFF
--- a/foxglove_bridge.tf
+++ b/foxglove_bridge.tf
@@ -2,7 +2,7 @@ locals {
   foxglove_bridge_team = [
     "achim-k",
     "defunctzombie",
-    "jhurliman",
+    "ericmlujan",
     "jtbandes",
   ]
   foxglove_bridge_repositories = [


### PR DESCRIPTION
# Updates to `foxglove_bridge` membership.

## New team members

* [@ericmlujan](https://github.com/foxglove/foxglove-sdk/blob/94fe5ff3e3c735804b699d71162dd233335c6ab5/ros/src/foxglove_bridge/package.xml#L8)

## Retiring team members

* @jhurliman

cc @jtbandes @defunctzombie as current Foxglove Bridge maintainers