### PR TITLE
Move 'zmqpp_vendor' repo from 'tier4' to 'autoware' team

### DIFF
--- a/autoware.tf
+++ b/autoware.tf
@@ -20,6 +20,7 @@ locals {
     "qpoases_vendor-release",
     "ros2_socketcan-release",
     "tvm_vendor-release",
+    "zmqpp_vendor-release",
   ]
 }
 

--- a/tier4.tf
+++ b/tier4.tf
@@ -12,7 +12,6 @@ locals {
     "heaphook-release",
     "osqp_vendor-release",
     "tensorrt_cmake_module-release",
-    "zmqpp_vendor-release",
   ]
 }
 


### PR DESCRIPTION
We would like to move the ownership of `zmqpp_vendor` repository from `tier4` (TIER IV) to `autoware` (Autoware Foundation) team.

You can check that:
- https://github.com/tier4/zmqpp_vendor will redirect to ⬇️
- https://github.com/autowarefoundation/zmqpp_vendor

@mitsudome-r is part of both `tier4` and `autoware` teams and an admin of https://github.com/autowarefoundation
@mitsudome-r has approved the change ✅

- Related PR: https://github.com/ros/rosdistro/pull/49111