### PR TITLE
Drop 'nuclearsandwich' from team membership

### DIFF
--- a/00-main.tf
+++ b/00-main.tf
@@ -12,7 +12,6 @@ locals {
     "cottsay",
     "gbiggs",
     "marcoag",
-    "nuclearsandwich",
     "tfoote",
     "vyorsi",
   ]

--- a/00-ros2_core.tf
+++ b/00-ros2_core.tf
@@ -19,7 +19,6 @@ locals {
     "methylDragon",
     "mjcarroll",
     "mjeronimo",
-    "nuclearsandwich",
     "quarkytale",
     "sloretz",
     "tfoote",

--- a/robotwebtools.tf
+++ b/robotwebtools.tf
@@ -5,7 +5,6 @@ locals {
     "defunctzombie",
     "dirk-thomas",
     "jtbandes",
-    "nuclearsandwich",
   ]
   robotwebtools_repositories = [
     "rosbridge_suite-release",


### PR DESCRIPTION
@nuclearsandwich, does it make sense to drop from all three of these teams? Maybe stay in `robotwebtools`?