### PR TITLE
Add scpeters to the ROS2 core release team

### DIFF
--- a/00-ros2_core.tf
+++ b/00-ros2_core.tf
@@ -20,6 +20,7 @@ locals {
     "mjcarroll",
     "mjeronimo",
     "quarkytale",
+    "scpeters",
     "sloretz",
     "tfoote",
     "wjwwood",


### PR DESCRIPTION
I've added @scpeters to the ROS 2 Core release team, so he will be able to release urdfdom_headers, urdfdom and urdf_parser_py

Please refer to comment: https://github.com/ros/urdfdom/issues/230#issuecomment-3829300819