### PR TITLE
Update autoware.tf to create autoware_rviz_plugins-release 

### DIFF
--- a/autoware.tf
+++ b/autoware.tf
@@ -16,6 +16,7 @@ locals {
     "autoware_internal_msgs-release",
     "autoware_lanelet2_extension-release",
     "autoware_msgs-release",
+    "autoware_rviz_plugins-release",
     "autoware_utils-release",
     "qpoases_vendor-release",
     "ros2_socketcan-release",


### PR DESCRIPTION
This PR has updated autoware.tf to append autoware_rviz_plugins-release to autoware_repositories
Please create above release repository.

The repository is already added to rosdistro in this PR: https://github.com/ros/rosdistro/pull/49106