### PR TITLE
Add socketcan_adapater release repo and zeerekahmad team member for Polymath Robotics 

### DIFF
--- a/polymath_robotics.tf
+++ b/polymath_robotics.tf
@@ -2,9 +2,11 @@ locals {
   polymath_robotics_team = [
     "emersonknapp",
     "troygibb",
+    "zeerekahmad",
   ]
   polymath_robotics_repositories = [
     "replay_testing-release",
+    "socketcan_adapter-release",
   ]
 }
 


### PR DESCRIPTION
Referencing #1001 

- Add zeerekahmad to the poliymath_robotics team
- Add socketcan_adapter-release repo (non-release already present in [rosdistro](https://github.com/ros/rosdistro/pull/50185))