### PR TITLE
Add resource_retriever_service-release additional repo to ros_core

### DIFF
--- a/00-ros2_core.tf
+++ b/00-ros2_core.tf
@@ -139,6 +139,7 @@ locals {
     "rcutils-release",
     "realtime_support-release",
     "resource_retriever-release",
+    "resource_retriever_service-release",
     "rmw-release",
     "rmw_connext-release", # archive after Foxy end-of-support
     "rmw_connextdds-release",


### PR DESCRIPTION
Code moved out of RViz into a new repo as a generic resource_retriever feature https://github.com/ros2/rviz/pull/1698/changes


Similar-ish situation to https://github.com/ros2-gbp/ros2-gbp-github-org/pull/817 . In this case code has been both split out and made generic.