### PR TITLE
Update Open-RMF Maintainers

### DIFF
--- a/rmf.tf
+++ b/rmf.tf
@@ -1,10 +1,11 @@
 locals {
   rmf_team = [
     "Yadunund",
-    "codebot",
     "luca-della-vedova",
-    "marcoag",
     "mxgrey",
+    "aaronchongth",
+    "arjo129",
+    "xiyuoh",
   ]
   rmf_repositories = [
     "ament_cmake_catch2-release",


### PR DESCRIPTION
This updates the `rmf_team` to reflect the current PMC of the Open-RMF project. This adds release permissions for @aaronchongth, @arjo129, and @xiyuoh.