### PR TITLE
Add RosGraph WG contributors to NoDL release team

### DIFF
--- a/nodl.tf
+++ b/nodl.tf
@@ -2,6 +2,9 @@ locals {
   nodl_team = [
     "Arnatious",
     "kyrofa",
+    "emersonknapp",
+    "lsy3",
+    "alistair-english",
   ]
   nodl_repositories = [
     "ament_nodl-release",

--- a/nodl.tf
+++ b/nodl.tf
@@ -1,10 +1,10 @@
 locals {
   nodl_team = [
     "Arnatious",
-    "kyrofa",
-    "emersonknapp",
-    "lsy3",
     "alistair-english",
+    "emersonknapp",
+    "kyrofa",
+    "lsy3",
   ]
   nodl_repositories = [
     "ament_nodl-release",


### PR DESCRIPTION
The other option I was considering here was adding `nodl-release` repo to the list for https://github.com/ros2-gbp/ros2-gbp-github-org/blob/latest/tooling_wg.tf - but that team spans kind of a wide range of stuff and this project has been pretty tightly scoped.

Either way, after the new WG spin-up, repo transfer, and new work, I need to add these new permissions for `nodl-release`

Closes https://github.com/ros-tooling/nodl/issues/124