### PR TITLE
Add 'rewire' release team

### DIFF
--- a/00-members.tf
+++ b/00-members.tf
@@ -196,6 +196,7 @@ locals {
     local.rdl_team,
     local.realsense_team,
     local.reductstore_team,
+    local.rewire_team,
     local.rmf_team,
     local.roadmap_explorer_team,
     local.roboception_team,

--- a/00-repositories.tf
+++ b/00-repositories.tf
@@ -196,6 +196,7 @@ locals {
     local.rdl_repositories,
     local.realsense_repositories,
     local.reductstore_repositories,
+    local.rewire_repositories,
     local.rmf_repositories,
     local.roadmap_explorer_repositories,
     local.roboception_repositories,

--- a/rewire.tf
+++ b/rewire.tf
@@ -1,0 +1,16 @@
+locals {
+  rewire_team = [
+    "alvgaona",
+  ]
+  rewire_repositories = [
+    "rewire_ros-release",
+  ]
+}
+
+module "rewire_team" {
+  source       = "./modules/release_team"
+  team_name    = "rewire"
+  members      = local.rewire_team
+  repositories = local.rewire_repositories
+  depends_on   = [github_membership.members, github_repository.repositories]
+}


### PR DESCRIPTION
Closes #1137.

Adds the `rewire` release team with one member and one repository, `rewire_ros-release`, for the `rewire` ROS 2 package.

The rosdistro entries are under review: 

- [humble rosdistro#53843](https://github.com/ros/rosdistro/pull/53847)
- [jazzy#53844](https://github.com/ros/rosdistro/pull/53844)
- [kilted rosdistro#53845](https://github.com/ros/rosdistro/pull/53845)
- [lyrical rosdistro#53846](https://github.com/ros/rosdistro/pull/53846) 
- [rolling rodistro#53847](https://github.com/ros/rosdistro/pull/53847)

The package is already released for the other four distributions from https://github.com/rewire-run/rewire-ros-release. Please import that repository into the new one so those branches carry over.
